### PR TITLE
Enhancements and fixes

### DIFF
--- a/spec/genie/api_spec.cr
+++ b/spec/genie/api_spec.cr
@@ -7,6 +7,36 @@ module Genie::Model
     Spec.before_each { WebMock.reset }
 
     describe "get" do
+      it "does not add query string if no params" do
+        api = Api.new(@@config)
+
+        WebMock.stub(:get, "http://localhost/genie/v2/jobs")
+          .to_return(body: "body", status: 200)
+
+        resp = api.get("/jobs", {} of String => String)
+
+        resp.success?.should eq(true)
+        resp.error?.should eq(false)
+        resp.status_code.should eq(200)
+        resp.unauthorized?.should eq(false)
+      end
+
+      it "escapes params" do
+        api = Api.new(@@config)
+
+        WebMock.stub(:get, "http://localhost/genie/v2/jobs?name=%25hi%25")
+          .to_return(body: "body", status: 200)
+
+        resp = api.get("/jobs", {
+          "name" => "%hi%"
+        })
+
+        resp.success?.should eq(true)
+        resp.error?.should eq(false)
+        resp.status_code.should eq(200)
+        resp.unauthorized?.should eq(false)
+      end
+
       it "returns a reasonable respone on error" do
         api = Api.new(@@config)
 

--- a/spec/genie/api_spec.cr
+++ b/spec/genie/api_spec.cr
@@ -11,7 +11,7 @@ module Genie::Model
         api = Api.new(@@config)
 
         WebMock.stub(:get, "http://localhost/genie/v2/jobs")
-          .to_return(body: "body", status: 200)
+               .to_return(body: "body", status: 200)
 
         resp = api.get("/jobs", {} of String => String)
 
@@ -25,10 +25,10 @@ module Genie::Model
         api = Api.new(@@config)
 
         WebMock.stub(:get, "http://localhost/genie/v2/jobs?name=%25hi%25")
-          .to_return(body: "body", status: 200)
+               .to_return(body: "body", status: 200)
 
         resp = api.get("/jobs", {
-          "name" => "%hi%"
+          "name" => "%hi%",
         })
 
         resp.success?.should eq(true)

--- a/spec/genie/cli/tabbed_printer_spec.cr
+++ b/spec/genie/cli/tabbed_printer_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 module Genie
   describe Cli::TabbedPrinter do
     it "can print no jobs" do
-      jobs = [ ] of Genie::Model::Job
+      jobs = [] of Genie::Model::Job
 
       printer = Genie::Cli::TabbedPrinter.new
 
@@ -20,7 +20,7 @@ module Genie
 
     it "prints jobs" do
       jobs = [
-        Genie::Model::Job.from_json(JOB_JSON)
+        Genie::Model::Job.from_json(JOB_JSON),
       ]
 
       printer = Genie::Cli::TabbedPrinter.new
@@ -39,7 +39,7 @@ module Genie
 
     it "can have headers specified" do
       jobs = [
-        Genie::Model::Job.from_json(JOB_JSON)
+        Genie::Model::Job.from_json(JOB_JSON),
       ]
 
       printer = Genie::Cli::TabbedPrinter.new
@@ -58,7 +58,7 @@ module Genie
 
     it "can have no header" do
       jobs = [
-        Genie::Model::Job.from_json(JOB_JSON)
+        Genie::Model::Job.from_json(JOB_JSON),
       ]
 
       printer = Genie::Cli::TabbedPrinter.new
@@ -73,6 +73,5 @@ module Genie
 
       printer.string.should eq(expected)
     end
-
   end
 end

--- a/spec/genie/cli/tabbed_printer_spec.cr
+++ b/spec/genie/cli/tabbed_printer_spec.cr
@@ -24,9 +24,11 @@ module Genie
       ]
 
       printer = Genie::Cli::TabbedPrinter.new
-
       printer.io = IO::Memory.new
-      printer.print(jobs, [] of String, false)
+
+      with_timezone("America/New_York") do
+        printer.print(jobs, [] of String, false)
+      end
 
       expected = <<-PRINTED
       id\tname\tstatus\tprogress\tstarted

--- a/spec/genie/cli/tabbed_printer_spec.cr
+++ b/spec/genie/cli/tabbed_printer_spec.cr
@@ -1,0 +1,78 @@
+require "../../spec_helper"
+
+module Genie
+  describe Cli::TabbedPrinter do
+    it "can print no jobs" do
+      jobs = [ ] of Genie::Model::Job
+
+      printer = Genie::Cli::TabbedPrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, [] of String, false)
+
+      expected = <<-PRINTED
+      id\tname\tstatus\tprogress\tstarted
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+    it "prints jobs" do
+      jobs = [
+        Genie::Model::Job.from_json(JOB_JSON)
+      ]
+
+      printer = Genie::Cli::TabbedPrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, [] of String, false)
+
+      expected = <<-PRINTED
+      id\tname\tstatus\tprogress\tstarted
+      123\tblah\tRUNNING\tN/A\t2017-05-01 15:56:53
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+    it "can have headers specified" do
+      jobs = [
+        Genie::Model::Job.from_json(JOB_JSON)
+      ]
+
+      printer = Genie::Cli::TabbedPrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, ["id"] of String, false)
+
+      expected = <<-PRINTED
+      id
+      123
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+    it "can have no header" do
+      jobs = [
+        Genie::Model::Job.from_json(JOB_JSON)
+      ]
+
+      printer = Genie::Cli::TabbedPrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, ["id"] of String, true)
+
+      expected = <<-PRINTED
+      123
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+  end
+end

--- a/spec/genie/cli/table_printer_spec.cr
+++ b/spec/genie/cli/table_printer_spec.cr
@@ -27,9 +27,11 @@ module Genie
       ]
 
       printer = Genie::Cli::TablePrinter.new
-
       printer.io = IO::Memory.new
-      printer.print(jobs, [] of String, false)
+
+      with_timezone("America/New_York") do
+        printer.print(jobs, [] of String, false)
+      end
 
       expected = <<-PRINTED
       +-----+------+---------+----------+---------------------+

--- a/spec/genie/cli/table_printer_spec.cr
+++ b/spec/genie/cli/table_printer_spec.cr
@@ -1,0 +1,89 @@
+require "../../spec_helper"
+
+module Genie
+  describe Cli::TablePrinter do
+    it "can print no jobs" do
+      jobs = [ ] of Genie::Model::Job
+
+      printer = Genie::Cli::TablePrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, [] of String, false)
+
+      expected = <<-PRINTED
+      +----+------+--------+----------+---------+
+      | id | name | status | progress | started |
+      +----+------+--------+----------+---------+
+      +----+------+--------+----------+---------+
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+    it "prints jobs" do
+      jobs = [
+        Genie::Model::Job.from_json(JOB_JSON)
+      ]
+
+      printer = Genie::Cli::TablePrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, [] of String, false)
+
+      expected = <<-PRINTED
+      +-----+------+---------+----------+---------------------+
+      | id  | name | status  | progress | started             |
+      +-----+------+---------+----------+---------------------+
+      | 123 | blah | RUNNING | N/A      | 2017-05-01 15:56:53 |
+      +-----+------+---------+----------+---------------------+
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+    it "can have headers specified" do
+      jobs = [
+        Genie::Model::Job.from_json(JOB_JSON)
+      ]
+
+      printer = Genie::Cli::TablePrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, ["id"] of String, false)
+
+      expected = <<-PRINTED
+      +-----+
+      | id  |
+      +-----+
+      | 123 |
+      +-----+
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+    it "can have no header" do
+      jobs = [
+        Genie::Model::Job.from_json(JOB_JSON)
+      ]
+
+      printer = Genie::Cli::TablePrinter.new
+
+      printer.io = IO::Memory.new
+      printer.print(jobs, ["id"] of String, true)
+
+      expected = <<-PRINTED
+      +-----+
+      | 123 |
+      +-----+
+
+      PRINTED
+
+      printer.string.should eq(expected)
+    end
+
+  end
+end

--- a/spec/genie/cli/table_printer_spec.cr
+++ b/spec/genie/cli/table_printer_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 module Genie
   describe Cli::TablePrinter do
     it "can print no jobs" do
-      jobs = [ ] of Genie::Model::Job
+      jobs = [] of Genie::Model::Job
 
       printer = Genie::Cli::TablePrinter.new
 
@@ -23,7 +23,7 @@ module Genie
 
     it "prints jobs" do
       jobs = [
-        Genie::Model::Job.from_json(JOB_JSON)
+        Genie::Model::Job.from_json(JOB_JSON),
       ]
 
       printer = Genie::Cli::TablePrinter.new
@@ -45,7 +45,7 @@ module Genie
 
     it "can have headers specified" do
       jobs = [
-        Genie::Model::Job.from_json(JOB_JSON)
+        Genie::Model::Job.from_json(JOB_JSON),
       ]
 
       printer = Genie::Cli::TablePrinter.new
@@ -67,7 +67,7 @@ module Genie
 
     it "can have no header" do
       jobs = [
-        Genie::Model::Job.from_json(JOB_JSON)
+        Genie::Model::Job.from_json(JOB_JSON),
       ]
 
       printer = Genie::Cli::TablePrinter.new
@@ -84,6 +84,5 @@ module Genie
 
       printer.string.should eq(expected)
     end
-
   end
 end

--- a/spec/genie/config_spec.cr
+++ b/spec/genie/config_spec.cr
@@ -22,7 +22,7 @@ module Genie
       it "defaults to localhost" do
         config = Config.new
 
-        config.host.should eq("localhost")
+        config.host.should eq("http://localhost")
       end
     end
 
@@ -111,7 +111,7 @@ module Genie
 
         config.username.should eq("blah")
         config.password.should eq("pass")
-        config.host.should eq("host")
+        config.host.should eq("http://host")
       end
     end
   end

--- a/spec/genie/model/job_spec.cr
+++ b/spec/genie/model/job_spec.cr
@@ -2,5 +2,32 @@ require "../../spec_helper"
 
 module Genie::Model
   describe Job do
+    describe "from_json" do
+      Spec.before_each do
+        @@OLD_TZ = ENV["TZ"]?
+        # ENV["TZ"] = "Eastern Time (US & Canada)"
+      end
+
+      Spec.after_each do
+        if @@OLD_TZ != nil
+          ENV["TZ"] = @@OLD_TZ
+        else
+          ENV["TZ"] = ""
+        end
+      end
+
+      it "uses local tz" do
+        json = {
+          "id" : "123",
+          "status" : "RUNNING",
+          "started" : "2017-05-01T19:56:53Z",
+          "name" : "blah",
+          "outputURI" : "uri"
+        }.to_json
+
+        job = Job.from_json(json)
+        job.started.should eq("2017-05-01 15:56:53")
+      end
+    end
   end
 end

--- a/spec/genie/model/job_spec.cr
+++ b/spec/genie/model/job_spec.cr
@@ -3,19 +3,6 @@ require "../../spec_helper"
 module Genie::Model
   describe Job do
     describe "from_json" do
-      Spec.before_each do
-        @@OLD_TZ = ENV["TZ"]?
-        # ENV["TZ"] = "Eastern Time (US & Canada)"
-      end
-
-      Spec.after_each do
-        if @@OLD_TZ != nil
-          ENV["TZ"] = @@OLD_TZ
-        else
-          ENV["TZ"] = ""
-        end
-      end
-
       it "uses local tz" do
         json = {
           "id" : "123",
@@ -26,7 +13,9 @@ module Genie::Model
         }.to_json
 
         job = Job.from_json(json)
-        job.started.should eq("2017-05-01 15:56:53")
+        with_timezone("America/New_York") do
+          job.started.should eq("2017-05-01 15:56:53")
+        end
       end
     end
   end

--- a/spec/genie_spec.cr
+++ b/spec/genie_spec.cr
@@ -2,6 +2,6 @@ require "./spec_helper"
 
 describe Genie do
   it "has a version" do
-    Genie::VERSION.should eq("0.1.5")
+    Genie::VERSION.should eq("0.1.6")
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,14 @@
 ENV["ENV"] = "test"
 ENV["LOG_LEVEL"] = "ERROR"
+
+JOB_JSON = {
+  "id" : "123",
+  "status" : "RUNNING",
+  "started" : "2017-05-01T19:56:53Z",
+  "name" : "blah",
+  "outputURI" : "uri"
+}.to_json
+
 require "spec"
 require "secure_random"
 require "webmock"

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -9,6 +9,14 @@ JOB_JSON = {
   "outputURI" : "uri"
 }.to_json
 
+def self.with_timezone(zone)
+  tz = ENV["TZ"]?
+  ENV["TZ"] = zone
+  ret = yield
+  ENV["TZ"] = tz
+  ret
+end
+
 require "spec"
 require "secure_random"
 require "webmock"

--- a/src/genie/api.cr
+++ b/src/genie/api.cr
@@ -69,7 +69,7 @@ module Genie
 
     # :nodoc:
     private def full_path(path)
-      "http://#{host}/genie/v2#{path}"
+      "#{host}/genie/v2#{path}"
     end
 
     # :nodoc:

--- a/src/genie/api.cr
+++ b/src/genie/api.cr
@@ -1,4 +1,6 @@
+require "uri"
 require "http/client"
+
 require "./api/response"
 require "./api/errors"
 
@@ -15,16 +17,16 @@ module Genie
 
     # Make a GET request to a path, using the host given by the configuration
     # api uri.
-    def get(path : String)
+    def get(path : String, params = {} of String => String)
       handle_error do
-        _get(full_path(path))
+        _get(full_path(path), params)
       end
     end
 
     # Make a GET request using a full URI.
-    def get(uri : URI)
+    def get(uri : URI, params = {} of String => String)
       handle_error do
-        _get(uri.to_s)
+        _get(uri.to_s, params)
       end
     end
 
@@ -54,10 +56,13 @@ module Genie
     end
 
     # :nodoc:
-    private def _get(url)
-      Response.new(
-        HTTP::Client.get(url, headers: @headers)
-      )
+    private def _get(url, params : Hash(String, String))
+      _url = url
+      if params.any?
+        _url = "#{_url}?#{params.map { |k, v| "#{k}=#{URI.escape(v)}" }.join("&")}"
+      end
+
+      Response.new(HTTP::Client.get(_url, headers: @headers))
     end
 
     # :nodoc:

--- a/src/genie/cli.cr
+++ b/src/genie/cli.cr
@@ -7,6 +7,7 @@ require "./cli/kill"
 require "./cli/list"
 require "./cli/search"
 require "./cli/status"
+require "./cli/open"
 
 module Genie::Cli
   # The base Cli
@@ -25,6 +26,9 @@ module Genie::Cli
 
     # Search for a Genie job.
     register_sub_command search, Cli::Search
+
+    # Open a Genie job.
+    register_sub_command open, Cli::Open
 
     def run
       puts help

--- a/src/genie/cli/base_command.cr
+++ b/src/genie/cli/base_command.cr
@@ -5,9 +5,9 @@ module Genie::Cli
       include PrinterFlag
       include HeaderFlag
       include ColumnsFlag
-      include ConfigFlag
       include ProgressFlag
       include LimitFlag
+      include EnvFlag
       define_help
     end
 
@@ -22,7 +22,7 @@ module Genie::Cli
 
     # :nodoc:
     private def config
-      Config.from_file(flags.config)
+      Config.from_env(flags.env)
     end
 
     # :nodoc:

--- a/src/genie/cli/flags.cr
+++ b/src/genie/cli/flags.cr
@@ -1,6 +1,6 @@
 require "./flags/columns_flag"
 require "./flags/header_flag"
-require "./flags/config_flag"
 require "./flags/progress_flag"
 require "./flags/limit_flag"
 require "./flags/printer_flag"
+require "./flags/env_flag"

--- a/src/genie/cli/flags/config_flag.cr
+++ b/src/genie/cli/flags/config_flag.cr
@@ -1,9 +1,0 @@
-module Genie::Cli
-  module ConfigFlag
-    # Adds a config option to any command
-    macro included
-      define_flag config : String, default: "~/.genie.yml",
-        description: "Specify an alternative .yml configuration file"
-    end
-  end
-end

--- a/src/genie/cli/flags/env_flag.cr
+++ b/src/genie/cli/flags/env_flag.cr
@@ -1,0 +1,9 @@
+module Genie::Cli
+  module EnvFlag
+    # Adds a limit option to any command
+    macro included
+      define_flag env : String?, default: nil, short: e,
+          description: "The env to use"
+    end
+  end
+end

--- a/src/genie/cli/open.cr
+++ b/src/genie/cli/open.cr
@@ -1,0 +1,16 @@
+module Genie::Cli
+  # Open a Genie Job
+  class Open < Admiral::Command
+    include BaseCommand
+
+    define_argument id, required: true
+
+    def run
+      client.open(open_options)
+    end
+
+    private def open_options
+      Client::OpenOptions.new(id: arguments.id)
+    end
+  end
+end

--- a/src/genie/cli/printer.cr
+++ b/src/genie/cli/printer.cr
@@ -1,6 +1,9 @@
 module Genie::Cli
   module Printer
     @rows = [] of Array(String)
+    @io : IO = STDOUT
+
+    property io
 
     abstract def render(hide_header = false)
 
@@ -29,6 +32,15 @@ module Genie::Cli
       end
 
       render(hide_header)
+    end
+
+    def string
+      @io.rewind
+      @io.gets_to_end
+    end
+
+    private def write(data)
+      @io.puts(data)
     end
 
     private def select_columns(columns)

--- a/src/genie/cli/printer.cr
+++ b/src/genie/cli/printer.cr
@@ -22,7 +22,12 @@ module Genie::Cli
         end
       end
 
-      select_columns(columns)
+      if jobs.any?
+        select_columns(columns)
+      else
+        hide_header = false
+      end
+
       render(hide_header)
     end
 

--- a/src/genie/cli/tabbed_printer.cr
+++ b/src/genie/cli/tabbed_printer.cr
@@ -7,7 +7,7 @@ module Genie::Cli
       @rows = @rows[1..-1] if hide_header
 
       @rows.each do |row|
-        puts(row.join("\t"))
+        write(row.join("\t"))
       end
     end
   end

--- a/src/genie/cli/table_printer.cr
+++ b/src/genie/cli/table_printer.cr
@@ -3,9 +3,7 @@ module Genie::Cli
   class TablePrinter
     include Printer
 
-    def initialize
-      @table = TerminalTable.new
-    end
+    @table = TerminalTable.new
 
     def render(hide_header)
       if hide_header == false
@@ -18,7 +16,7 @@ module Genie::Cli
         @table << row
       end
 
-      puts(@table.render)
+      write(@table.render)
     end
   end
 end

--- a/src/genie/client.cr
+++ b/src/genie/client.cr
@@ -87,7 +87,7 @@ module Genie
     private def fetch_progress(job)
       regex = /(?<progress>[0-9]+%)+/
 
-      uri = URI.parse("http://#{@config.host}/genie-jobs/#{job.id}/stderr.log")
+      uri = URI.parse("#{@config.host}/genie-jobs/#{job.id}/stderr.log")
       stderr = begin
         resp = @api.get(uri)
         resp.body

--- a/src/genie/client.cr
+++ b/src/genie/client.cr
@@ -3,12 +3,17 @@ require "./client/list_options"
 require "./client/search_options"
 require "./client/kill_options"
 require "./client/status_options"
+require "./client/open_options"
 
 module Genie
   # A Genie client
   class Client
     def initialize(@config : Config)
       @api = Api.new(@config)
+    end
+
+    def open(options : OpenOptions)
+      `open #{@config.host}/genie-jobs/#{options.id}/`
     end
 
     # Search for a Genie job by name.

--- a/src/genie/client.cr
+++ b/src/genie/client.cr
@@ -19,9 +19,9 @@ module Genie
     # Search for a Genie job by name.
     def search(options : SearchOptions) : Array(Model::Job)
       resp = get("/jobs", {
-          "limit" => options.limit.to_s,
-          "name" => options.name
-        }
+        "limit" => options.limit.to_s,
+        "name"  => options.name,
+      }
       )
 
       jobs = Array(Model::Job).from_json(resp.body)
@@ -34,7 +34,7 @@ module Genie
     # List Genie jobs
     def list(options : ListOptions) : Array(Model::Job)
       resp = get("/jobs", {
-        "limit" => options.limit.to_s
+        "limit" => options.limit.to_s,
       })
 
       jobs = Array(Model::Job).from_json(resp.body)

--- a/src/genie/client.cr
+++ b/src/genie/client.cr
@@ -18,7 +18,12 @@ module Genie
 
     # Search for a Genie job by name.
     def search(options : SearchOptions) : Array(Model::Job)
-      resp = get("/jobs?limit=#{options.limit}&name=#{options.name}")
+      resp = get("/jobs", {
+          "limit" => options.limit.to_s,
+          "name" => options.name
+        }
+      )
+
       jobs = Array(Model::Job).from_json(resp.body)
 
       add_progress!(jobs) if options.progress
@@ -28,7 +33,10 @@ module Genie
 
     # List Genie jobs
     def list(options : ListOptions) : Array(Model::Job)
-      resp = get("/jobs?limit=#{options.limit}")
+      resp = get("/jobs", {
+        "limit" => options.limit.to_s
+      })
+
       jobs = Array(Model::Job).from_json(resp.body)
 
       add_progress!(jobs) if options.progress
@@ -57,8 +65,8 @@ module Genie
       jobs
     end
 
-    private def get(url)
-      handle_api_error { @api.get(url) }
+    private def get(url, params = {} of String => String)
+      handle_api_error { @api.get(url, params) }
     end
 
     private def delete(url)

--- a/src/genie/client/open_options.cr
+++ b/src/genie/client/open_options.cr
@@ -1,0 +1,11 @@
+module Genie
+  class Client
+    # Options for opening a job
+    class OpenOptions
+      getter id
+
+      def initialize(@id : String)
+      end
+    end
+  end
+end

--- a/src/genie/config.cr
+++ b/src/genie/config.cr
@@ -9,11 +9,11 @@ module Genie
       credentials: Credentials?,
       host:        String?,
       printer:     String?,
-      columns:     { type: Array(String), default: [] of String }
+      columns:     {type: Array(String), default: [] of String},
     })
 
     def self.from_env(env)
-      parts  = ["~/", "genie", env, "yml"].compact.join(".")
+      parts = ["~/", "genie", env, "yml"].compact.join(".")
       from_file(parts)
     end
 

--- a/src/genie/config.cr
+++ b/src/genie/config.cr
@@ -12,6 +12,11 @@ module Genie
       columns:     { type: Array(String), default: [] of String }
     })
 
+    def self.from_env(env)
+      parts  = ["~/", "genie", env, "yml"].compact.join(".")
+      from_file(parts)
+    end
+
     # Instantiate a `Config` object from a file.
     def self.from_file(file)
       begin

--- a/src/genie/config.cr
+++ b/src/genie/config.cr
@@ -3,7 +3,7 @@ require "yaml"
 module Genie
   # Holds Configuration
   class Config
-    DEFAULT_HOST = "localhost"
+    DEFAULT_HOST = "http://localhost"
 
     YAML.mapping({
       credentials: Credentials?,
@@ -28,6 +28,14 @@ module Genie
     def initialize(@credentials = nil)
       @host = DEFAULT_HOST
       @columns = [] of String
+    end
+
+    def host
+      if @host.not_nil!.starts_with?("http://")
+        @host
+      else
+        "http://#{@host}"
+      end
     end
 
     # The username used for API auth

--- a/src/genie/model/job.cr
+++ b/src/genie/model/job.cr
@@ -15,6 +15,10 @@ module Genie
         started: Time
       )
 
+      def started
+        @started.to_local.to_s("%Y-%m-%d %H:%M:%S")
+      end
+
       def_equals id, status, name, output_uri, started
     end
   end

--- a/src/genie/version.cr
+++ b/src/genie/version.cr
@@ -1,7 +1,7 @@
 module Genie
   MAJOR = "0"
   MINOR = "1"
-  PATCH = "5"
+  PATCH = "6"
 
   # CLI Version
   VERSION = [


### PR DESCRIPTION
- Removes `--config` flag in favor of an `-e` flag representing the environment
- Fixes crash when the search command returned no jobs
- Fixes issue where the search command would not properly escape the search query
- Fixes issue where jobs were printed with their start time in the wrong timezone
- Adds tests for the two printers
- Adds `genie open` to open the job output directory