### PR TITLE
add configurable output name length

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ columns:
   - name
 ```
 
+You may choose to truncate the job name after a certain number of characters.
+
+```
+name_length: 25
+```
+
 ## Usage
 
 **List Genie Jobs**

--- a/spec/genie/config_spec.cr
+++ b/spec/genie/config_spec.cr
@@ -27,6 +27,26 @@ module Genie
     end
 
     describe "from_file" do
+      it "can parse name length" do
+        path = "/tmp/#{SecureRandom.uuid}"
+
+        File.write(path, <<-YAML
+                   name_length: 123
+                   YAML
+        )
+
+        config = Config.from_file(path)
+
+        config.name_length.should eq(123)
+      end
+
+      it "has a default name length of -1" do
+        path = "/tmp/#{SecureRandom.uuid}"
+        config = Config.from_file(path)
+
+        config.name_length.should eq(-1)
+      end
+
       it "can parse columns" do
         path = "/tmp/#{SecureRandom.uuid}"
 

--- a/src/genie/cli/base_command.cr
+++ b/src/genie/cli/base_command.cr
@@ -17,7 +17,7 @@ module Genie::Cli
                 else
                   config.columns.not_nil!
                 end
-      printer.print(jobs, columns, flags.hide_header)
+      printer.print(jobs, columns, flags.hide_header, config.name_length)
     end
 
     # :nodoc:

--- a/src/genie/cli/printer.cr
+++ b/src/genie/cli/printer.cr
@@ -7,7 +7,7 @@ module Genie::Cli
 
     abstract def render(hide_header = false)
 
-    def print(jobs, columns, hide_header)
+    def print(jobs, columns, hide_header, name_length = -1)
       columns = headers if columns.empty?
 
       if (columns & headers).size == 0
@@ -19,9 +19,9 @@ module Genie::Cli
 
       jobs.each do |job|
         if job.progress
-          @rows << [job.id, job.name, job.status, "#{job.progress}%", job.started.to_s]
+          @rows << [job.id, job.name[0..name_length], job.status, "#{job.progress}%", job.started.to_s]
         else
-          @rows << [job.id, job.name, job.status, "N/A", job.started.to_s]
+          @rows << [job.id, job.name[0..name_length], job.status, "N/A", job.started.to_s]
         end
       end
 

--- a/src/genie/config.cr
+++ b/src/genie/config.cr
@@ -9,7 +9,8 @@ module Genie
       credentials: Credentials?,
       host:        String?,
       printer:     String?,
-      columns:     {type: Array(String), default: [] of String},
+      columns:     { type: Array(String), default: [] of String },
+      name_length: { type: Int64, default: -1.to_i64 }
     })
 
     def self.from_env(env)
@@ -33,6 +34,7 @@ module Genie
     def initialize(@credentials = nil)
       @host = DEFAULT_HOST
       @columns = [] of String
+      @name_length = -1.to_i64
     end
 
     def host


### PR DESCRIPTION
- adds optional config to truncate job name